### PR TITLE
1.0.300

### DIFF
--- a/CSTNet.Tests/CSTHelper.cs
+++ b/CSTNet.Tests/CSTHelper.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 
-namespace CSTNet.Tests
+namespace Sixam.CST.Tests
 {
     static class CSTHelper
     {

--- a/CSTNet.Tests/MultilineTests.cs
+++ b/CSTNet.Tests/MultilineTests.cs
@@ -1,7 +1,7 @@
 using System;
 using Xunit;
 
-namespace CSTNet.Tests
+namespace Sixam.CST.Tests
 {
     public class MultilineTests
     {

--- a/CSTNet.Tests/SingleLineTests.cs
+++ b/CSTNet.Tests/SingleLineTests.cs
@@ -1,7 +1,8 @@
 // This project is licensed under the MIT license.
+
 using Xunit;
 
-namespace CSTNet.Tests
+namespace Sixam.CST.Tests
 {
     public class SingleLineTests
     {

--- a/CSTNet.Tests/v2.cst
+++ b/CSTNet.Tests/v2.cst
@@ -1,4 +1,4 @@
 Singleline^Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ultricies nulla eu tortor mattis, dictum posuere lacus ornare. Maecenas a massa in ligula finibus luctus eu vitae nibh. Proin imperdiet dapibus mauris quis placerat.^
 Multiline ^Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc gravida nunc non justo pretium consectetur. Sed tempus libero ac ligula aliquam elementum. Duis vitae interdum leo. Sed semper nulla %1 a lectus dictum dictum.
 
-Quisque vehicula, nisi ut scelerisque sodales, nisi ipsum sodales ipsum, in rutrum tellus lacus sed nibh. Etiam mauris velit, elementum sed placerat et, elementum et tellus. Duis vitae elit fermentum, viverra lorem in, lobortis elit^
+Quisque vehicula, nisi ut scelerisque sodales, nisi ipsum sodales ipsum, in rutrum tellus lacus sed nibh. Etiam mauris velit, elementum sed placerat et, elementum et tellus. Duis vitae elit fermentum, viverra lorem in, lobortis elit.^

--- a/CSTNet.sln.licenseheader
+++ b/CSTNet.sln.licenseheader
@@ -1,3 +1,0 @@
-extensions: designer.cs generated.cs
-extensions: .cs .cpp .h
-// This project is licensed under the MIT license.

--- a/CSTNet/CaretSeparatedText.cs
+++ b/CSTNet/CaretSeparatedText.cs
@@ -1,26 +1,26 @@
 // This project is licensed under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
-namespace CSTNet
+namespace Sixam.CST
 {
-    public static class CaretSeparatedText
+    public class CaretSeparatedText
     {
+
         const char CARET = '^';
-        static readonly string _lf = "\u000A";
-        static readonly string _cr = "\u000D";
-        static readonly string _crlf = "\u000D\u000A";
-        static readonly string _ls = "\u2028";
+        const string LF = "\u000A";
+        const string CR = "\u000D";
+        const string CRLF = "\u000D\u000A";
+        const string LS = "\u2028";
 
         /// <summary>
-        /// Gets the value from the integer-based key.
+        /// Gets the value from the digit-based key.
         /// </summary>
         /// <returns>Returns the entry</returns>
-        public static string Parse(string content, int key)
-        {
-            var entries = NormalizeEntries(content);
-            return GetEntry(entries, key.ToString());
-        }
+        public static string Parse(string content, int key) => Parse(content, key.ToString());
 
         /// <summary>
         /// Gets the value from the string-based key.
@@ -40,34 +40,28 @@ namespace CSTNet
         {
             if (!content.Contains(Environment.NewLine))
             {
-                if (content.Contains(_lf))
-                    content = content.Replace(_lf, Environment.NewLine);
+                if (content.Contains(LF))
+                    content = content.Replace(LF, Environment.NewLine);
 
-                if (content.Contains(_cr))
-                    content = content.Replace(_cr, Environment.NewLine);
+                if (content.Contains(CR))
+                    content = content.Replace(CR, Environment.NewLine);
 
-                if (content.Contains(_crlf))
-                    content = content.Replace(_crlf, Environment.NewLine);
+                if (content.Contains(CRLF))
+                    content = content.Replace(CRLF, Environment.NewLine);
 
-                if (content.Contains(_ls))
-                    content = content.Replace(_ls, Environment.NewLine);
+                if (content.Contains(LS))
+                    content = content.Replace(LS, Environment.NewLine);
             }
 
             var lines = content.Split(new[] { $"{CARET}{Environment.NewLine}" },
                 StringSplitOptions.RemoveEmptyEntries);
-            var entries = new List<string>();
 
-            foreach (var line in lines)
-            {
-                // Skip comments
-                if (line.StartsWith("//") || line.StartsWith("#") ||
-                    line.StartsWith("/*") || line.EndsWith("*/"))
-                    continue;
-
-                entries.Add(line);
-            }
-
-            return entries;
+            return lines.Where(line =>
+                    !line.StartsWith("//") &&
+                    !line.StartsWith("#") &&
+                    !line.StartsWith("/*") &&
+                    !line.EndsWith("*/"))
+                .AsEnumerable();
         }
 
         static string GetEntry(IEnumerable<string> entries, string key)
@@ -89,4 +83,10 @@ namespace CSTNet
             return "***MISSING***";
         }
     }
+}
+
+namespace CSTNet
+{
+    [Obsolete("CaretSeparatedText has moved to the Sixam.CST namespace.")]
+    public class CaretSeparatedText : Sixam.CST.CaretSeparatedText { }
 }

--- a/CSTNet/Sixam.CST.csproj
+++ b/CSTNet/Sixam.CST.csproj
@@ -2,9 +2,13 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <Version>1.0.2</Version>
-        <Authors>Tony Bark</Authors>
-        <PackageDescription>Caret-Separated Text (or CST) is a key-value pair format represented by numbers or words as keys and the value is the string enclosed between carets (^) that contains the contents. CST.NET is a library for prasing the CST format.</PackageDescription>
+        <Version>1.0.300</Version>
+        <Authors>Tony Bark, Sixam Software</Authors>
+        <PackageDescription>
+            Caret-Separated Text (or CST) is a key-value pair format represented by numbers or words as keys and the value is the string enclosed between carets that contains the contents. ([key] ^[value]^)
+
+            CST.NET is a parser for the CST format.
+        </PackageDescription>
         <RepositoryUrl>https://github.com/sixamsoft/cst-dotnet</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Product>CST.Net</Product>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Caret-Separated Text (or CST) is a key-value pair format represented by digits o
 ```
 
 ```csharp
-#r "nuget:CSTNet,1.0.2"
+#r "nuget:CSTNet,1.0.300"
 using System;
 using System.IO;
 using CSTNet;

--- a/Sixam.CST.sln
+++ b/Sixam.CST.sln
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		changelog.md = changelog.md
 		README.md = README.md
+		Sixam.CST.sln.licenseheader = Sixam.CST.sln.licenseheader
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sixam.CST.Tests", "CSTNet.Tests\Sixam.CST.Tests.csproj", "{B6A98C64-1419-4B9A-99CA-72BB11D29472}"

--- a/Sixam.CST.sln.licenseheader
+++ b/Sixam.CST.sln.licenseheader
@@ -1,0 +1,4 @@
+extensions: designer.cs generated.cs
+extensions: .cs .cpp .h
+// This project is licensed under the MIT license.
+// See the LICENSE file in the project root for more information.

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,18 @@
 # Change Log
+
+## 1.0.300
+
+- Switched to Sixam.CST namespace and marked CSTNet namespace as obsolete.
+- Performance improvements.
+
 ## 1.0.2
 
 - Fixed the multiple line parsing in the v2 format.
 - Replaced "``[ENTRY NOT FOUND]``" message with "``***MISSING***``".
+
 ## 1.0.1
 
-Despite only being a point release, this includes a major refinement to the normalizing algorithm.
+Despite only being a patch release, this includes a major refinement to the normalizing algorithm.
 
 ### Rewrote normalizing algorithm
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 - Switched to Sixam.CST namespace and marked CSTNet namespace as obsolete.
 - Performance improvements.
+- Patch numbers are now in the triple digits.
 
 ## 1.0.2
 


### PR DESCRIPTION
- Switched to Sixam.CST namespace and marked CSTNet namespace as obsolete.
- Renumbered patch version from single to triple digits.
- Performance improvements.